### PR TITLE
fix sigsegv/sigabrt on pmt_packets pointer

### DIFF
--- a/libmpegts.c
+++ b/libmpegts.c
@@ -423,7 +423,7 @@ static int eject_queued_pmt( ts_writer_t *w, ts_int_program_t *program, bs_t *s 
         memmove( &program->pmt_packets[0], &program->pmt_packets[1], (program->num_queued_pmt-1) * sizeof(uint8_t*) );
 
     temp = realloc( program->pmt_packets, (program->num_queued_pmt-1) * sizeof(uint8_t*) );
-    if( !temp )
+    if( !temp && program->num_queued_pmt > 1 )
     {
         fprintf( stderr, "malloc failed\n" );
         return -1;


### PR DESCRIPTION
program->pmt_packets was not set to NULL when a realloc() frees it (the new size was 0)